### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/content/help/publications.md
+++ b/content/help/publications.md
@@ -10,14 +10,14 @@ launched!
 
 <div class="grey_box">
 Ramos, M, et al. (2017) <a
-href="https://dx.doi.org/10.1158/0008-5472.CAN-17-0344">Software for
+href="https://doi.org/10.1158/0008-5472.CAN-17-0344">Software for
 the Integration of Multiomics Experiments in Bioconductor</a>
 Cancer Research 77:e39-e42.
 doi:10.1158/0008-5472.CAN-17-0344
 </div>
 
 <div class="white_box">
-Pasolli, E, et al. (2017) <a href="https://dx.doi.org/10.1038/nmeth.4468">
+Pasolli, E, et al. (2017) <a href="https://doi.org/10.1038/nmeth.4468">
 Accessible, curated metagenomic data through ExperimentHub</a>
 Nature Methods 14, 1023–1024. doi:10.1038/nmeth.4468
 </div>
@@ -31,7 +31,7 @@ doi:10.1038/nmeth.3252 (full-text free with registration).
 
 <div class="white_box">
 Lawrence M, Huber W, Pagès H, Aboyoun P, Carlson M, et al. (2013) <a
-href="http://dx.doi.org/10.1371/journal.pcbi.1003118">Software for
+href="https://doi.org/10.1371/journal.pcbi.1003118">Software for
 Computing and Annotating Genomic Ranges</a>. PLoS Comput Biol 9(8):
 e1003118. doi: 10.1371/journal.pcbi.1003118
 </div>

--- a/content/news/bioc_3_3_release.md
+++ b/content/news/bioc_3_3_release.md
@@ -7231,7 +7231,7 @@ Changes in version 1.1.19:
 Changes in version 1.1.18:
 
 - Update lgg and gbm subtype information. Source:
-  http://dx.doi.org/10.1016/j.cell.2015.12.028
+  https://doi.org/10.1016/j.cell.2015.12.028
 
 Changes in version 1.1.17:
 

--- a/layouts/_pubmed.html
+++ b/layouts/_pubmed.html
@@ -3,7 +3,7 @@
 <div>
   <% @pb_item.children.each_with_index do |p, i| %>
     <div class="<%= "#{i % 2 == 0 ? 'grey_box' : 'white_box'}" %>">
-    <%= p[:author] %>. <a href="http://dx.doi.org/<%= p[:doi] %>" title="<%= p[:doi] %>" target="_blank"><%= p[:title] %></a>
+    <%= p[:author] %>. <a href="https://doi.org/<%= p[:doi] %>" title="<%= p[:doi] %>" target="_blank"><%= p[:title] %></a>
     <em><%= p[:journal] %></em><%= printIfExists(", <b>", p[:volume], "</b>") %><%= printIfExists("(", p[:issue], ")") %><%= printIfExists(", pp. ", p[:pages], "") %>.
     doi:<%= p[:doi] %> (<%= p[:date].strftime("%-d %B %Y") %>)
     </div>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!