### PR TITLE
generate https URLs

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1657,7 +1657,7 @@ end
 def get_short_url(package, full=false)
   url =  "/packages/#{package[:Package]}/"
   if full
-    "http://bioconductor.org#{url}"
+    "https://bioconductor.org#{url}"
   else
     url
   end


### PR DESCRIPTION
This is used for e.g. 'Package Short Url | http://bioconductor.org/packages/xcms/`
which should be a https URL. Closing #34