### PR TITLE
Change user name of docker images

### DIFF
--- a/content/help/docker.md
+++ b/content/help/docker.md
@@ -49,12 +49,12 @@ or [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/).
 
 	RStudio will be available on your web browser at
 	`https://localhost:8787`. The USER is fixed to always being
-	`bioc`. The password in the above command is given as `bioc` but
+	`rstudio`. The password in the above command is given as `bioc` but
 	it can be set to anything. `8787` is the port being mapped between
 	the docker container and your host machine. NOTE: password cannot
 	be `rstudio`.
 
-	The user is logged into the `bioc` user by default.
+	The user is logged into the `rstudio` user by default.
 
 <a name="intro"></a>
 ## Why use Containers


### PR DESCRIPTION
As explained in some slides the user of the docker images is `rstudio`, having the bioc as user confused me for a while.