### PR TITLE
accomodate for new macOS 10.13 (High Sierra) binaries

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ active_release_builders:
 active_devel_builders:
   linux: "malbec2"
   windows: "tokay2"
-  mac_elcapitan: "celaya2"
+  mac_highsierra: "machv2"
 
 ## CHANGE this when the single package builder builds
 ## on a newer version of bioc

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -754,7 +754,8 @@ end
 
 def mac_os(pkg)
   if pkg.has_key? :"mac.binary.ver"
-    return "Mac OS X 10.6 (Snow Leopard)"
+    #return "Mac OS X 10.6 (Snow Leopard)"
+    return "macOS 10.13 (High Sierra)"
   elsif pkg.has_key? :"mac.binary.mavericks.ver"
     return "Mac OS X 10.9 (Mavericks)"
   elsif pkg.has_key? :"mac.binary.el-capitan.ver"
@@ -900,9 +901,14 @@ def get_mac_packs(package, item)
         osvers << "mac.binary.mavericks.ver"
     end
 
-    if version >= Gem::Version.new('3.5')
+    if version >= Gem::Version.new('3.5') and version < Gem::Version.new('3.11')
         os <<  "Mac OS X 10.11 (El Capitan)"
         osvers << "mac.binary.el-capitan.ver"
+    end
+
+    if version >= Gem::Version.new('3.11')
+        os <<  "macOS 10.13 (High Sierra)"
+        osvers << "mac.binary.ver"
     end
 
     os.each_with_index do |this_os, i|

--- a/scripts/make_build_rss_feeds.rb
+++ b/scripts/make_build_rss_feeds.rb
@@ -149,7 +149,8 @@ def make_individual_feed(pkglist, config, pkgs_to_update)
                 os = {"linux" => 1, "windows" => 2,
                       "mac_snowleopard" => 3,
                       "mac_mavericks" => 4,
-                      "mac_elcapitan" => 5}
+                      "mac_elcapitan" => 5,
+                      "mac_highsierra" => 6}
                 for ary in [relprobs, devprobs]
                     machines = ary == relprobs ? config["active_release_builders"] : config["active_devel_builders"]
                     ary = ary.find_all{|i| machines.values.include? i[:node]}


### PR DESCRIPTION
I think we need a few small tweaks along those lines to make the new macOS 10.13 (High Sierra) binaries show up on the package landing pages for BioC 3.11 (e.g. [here](https://bioconductor.org/packages/3.11/Biobase)).