### PR TITLE
Edit Bioconductor Events calendar display after the 2020-06-11 CAB mtg

### DIFF
--- a/content/help/events.html
+++ b/content/help/events.html
@@ -1,5 +1,10 @@
 <h1><img src="/images/icons/calendar.gif" alt=""/>Events</h1>
 
+<h2>Events Google calendar</h2>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%2333B679&amp;ctz=America%2FNew_York&amp;src=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%238E24AA" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<p>
+    <a class="symlink" href="https://calendar.google.com/calendar/b/1?cid=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">Click here</a> to add the events calendar to Google calendar. To add an event, send an email to <i>events at bioconductor.org</i>.
+
 <h2>Course material</h2>
 <p>
 <a href="/help/course-materials/">Course material</a> from many

--- a/content/help/events.html
+++ b/content/help/events.html
@@ -3,7 +3,7 @@
 <h2>Events Google calendar</h2>
 <iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%2333B679&amp;ctz=America%2FNew_York&amp;src=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%238E24AA" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 <p>
-    <a class="symlink" href="https://calendar.google.com/calendar/b/1?cid=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">Click here</a> to add the events calendar to Google calendar. To add an event, send an email to <i>events at bioconductor.org</i>.
+    <a class="symlink" href="https://calendar.google.com/calendar/b/1?cid=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">Click here</a> to add the events calendar to your Google calendar. To add an event, send an email to <i>events at bioconductor.org</i>.
 
 <h2>Course material</h2>
 <p>

--- a/content/help/events.html
+++ b/content/help/events.html
@@ -1,7 +1,7 @@
 <h1><img src="/images/icons/calendar.gif" alt=""/>Events</h1>
 
 <h2>Events Google calendar</h2>
-<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%2333B679&amp;ctz=America%2FNew_York&amp;src=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%238E24AA" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FNew_York&amp;src=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%231A81C2" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 <p>
     <a class="symlink" href="https://calendar.google.com/calendar/b/1?cid=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">Click here</a> to add the events calendar to your Google calendar. To add an event, send an email to <i>events at bioconductor.org</i>.
 

--- a/layouts/_use.html
+++ b/layouts/_use.html
@@ -11,15 +11,15 @@
     </li>
     <li><a class="symlink" href="/help/docker/">Docker</a> and
       <a class="symlink" href="/help/bioconductor-cloud-ami/">Amazon</a> machine images</li>
-    <li>Latest <a class="symlink" href="/news/bioc_<%= config[:release_version].sub(".", "_") %>_release/">release annoucement</a></li>
+    <li>Latest <a class="symlink" href="/news/bioc_<%= config[:release_version].sub(".", "_") %>_release/">release announcement</a></li>
     <li> Use <em>Bioconductor</em> in
       the <a href="https://anvilproject.org">AnVIL</a>. See
       our <a href="https://bioconductor.github.io/AnVIL_Admin/">project
         updates</a>.</li>
     <li><a class="symlink" href="https://bioc-community.herokuapp.com/">Community Slack</a> sign-up<li>
     <li><a class="symlink" href="/help/support/">Support site</a></li>
-    <li><a class="symlink" href="https://calendar.google.com/calendar/b/1?cid=YWtlczFvZGVsbW9kcDAzODV1ZHB2NDhpY29AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">Events
-	      calendar</a>; email events at bioconductor.org to add an
+    <li><a class="symlink" href="http://bioconductor.org/help/events/">Events
+	      calendar</a>; email <i>events at bioconductor.org</i> to add an
 	      event.</li>
   </ul>
 </div>


### PR DESCRIPTION
Hi,

This PR now puts the link to add the Events calendar to your calendar inside http://bioconductor.org/help/events/ and it also embeds the Google Calendar there. More info on embedding at https://support.google.com/calendar/answer/41207?hl=en.

Among the color options I saw on the UI, I chose a "green" (sage) that looked kind of like the Bioconductor colors, but it might be worth trying changing `color=%238E24AA` (in the embed code) to `color=%87b13f` (from http://bioconductor.org/about/logo/). 

Best,
Leo