### PR TITLE
add books part to devel_repos

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,6 +33,7 @@ devel_repos:
 - "data/experiment"
 - "workflows"
 - "data/annotation"
+- "books"
 
 ## CHANGE this when the build machines change:
 ## also, don't include machines that are not building yet (comment them out)


### PR DESCRIPTION
These appear to be added to versions back to 3.12, so should be present in devel, too?