### PR TITLE
Add page for the European Bioconductor Society

### DIFF
--- a/content/about/european-bioconductor-society.md
+++ b/content/about/european-bioconductor-society.md
@@ -1,0 +1,20 @@
+# ![](/images/icons/magnifier.gif)European Bioconductor Society eV
+
+The society aims to facility the organisation of logistics of Bioconductor associated conferences, workshops and training events within Europe.  ![](https://raw.githubusercontent.com/Bioconductor/BiocStickers/master/boards/EuroBioC/EuroBioC.png)
+
+# Organisation
+
+| Chair: Dr. Wolfgang Huber |
+| Deputy Chairs: Dr. Charlotte Soneson and Prof. Laurent Gatto |
+| Treasurer and Secretary: Simone Bell |
+
+# Address
+
+European Bioconductor Society eV
+c/o Simone Bell
+Am Nachtwaidgraben 25
+68799 Reilingen
+
+
+
+

--- a/content/about/european-bioconductor-society.md
+++ b/content/about/european-bioconductor-society.md
@@ -1,19 +1,28 @@
 # ![](/images/icons/magnifier.gif)European Bioconductor Society eV
 
-The society aims to facility the organisation of logistics of Bioconductor associated conferences, workshops and training events within Europe.  ![](https://raw.githubusercontent.com/Bioconductor/BiocStickers/master/boards/EuroBioC/EuroBioC.png)
+<table>
+  <tbody>
+    <tr>
+      <td>The European Bioconductor Society eV is a registered association in Germany, created to support Bioconductor's mission to promote open source software in the life sciences and statistics. The society aims to facilitate the organisation and logistics of Bioconductor associated conferences, workshops, and training events across Europe. </td>
+      <td><img src="https://raw.githubusercontent.com/Bioconductor/BiocStickers/master/boards/EuroBioC/EuroBioC.png" alt="European Bioconductor Society Logo" width="210px"/></td>
+    </tr>
+  </tbody>
+</table>
 
 # Organisation
 
-| Chair: Dr. Wolfgang Huber |
-| Deputy Chairs: Dr. Charlotte Soneson and Prof. Laurent Gatto |
-| Treasurer and Secretary: Simone Bell |
+| **Chair:** Dr. Wolfgang Huber |
+| **Deputy Chairs:** Dr. Charlotte Soneson and Prof. Laurent Gatto |
+| **Treasurer and Secretary:** Simone Bell |
 
-# Address
 
-European Bioconductor Society eV
-c/o Simone Bell
-Am Nachtwaidgraben 25
-68799 Reilingen
+# Postal Address
+
+| European Bioconductor Society eV |
+| c/o Simone Bell |
+| Am Nachtwaidgraben 25 |
+| 68799 Reilingen |
+| Germany |
 
 
 

--- a/content/about/european-bioconductor-society.yaml
+++ b/content/about/european-bioconductor-society.yaml
@@ -1,0 +1,2 @@
+--- 
+title: European Bioconductor Society


### PR DESCRIPTION
This hopefully adds a more "official" web presence for the details of the European Society, so we can move away from the temporary page at https://www.embl.org/groups/huber/european-bioconductor-society-ev/

Happy to discuss if it's in an inappropriate place or we want to change the name etc.