### PR TITLE
Fix broken "Use binary package" section

### DIFF
--- a/content/help/docker.md
+++ b/content/help/docker.md
@@ -21,7 +21,7 @@ or [Microsoft Azure Container Instances](https://azure.microsoft.com/en-us/servi
   * [Running Containers](#running)
   * [Mounting Additional Volume](#mounting)
   * [Using docker-compose](#dockercompose)
-  * [Using Binary Packages] (#binarypackages)
+  * [Using Binary Packages](#binarypackages)
 - [Modifying Containers](#modify)
 - [Singularity](#singularity)
 - [Microsoft Azure Container Instances](#msft)


### PR DESCRIPTION
<img width="1087" alt="Screen Shot 2022-10-04 at 2 56 51 PM" src="https://user-images.githubusercontent.com/2746443/193903504-1ea77174-a492-41e5-86a9-7eca7c372415.png">

Needs merging with bioconductor git server.