### PR TITLE
Add code browser entry to package landing pages

### DIFF
--- a/layouts/_bioc_views_package_detail.html
+++ b/layouts/_bioc_views_package_detail.html
@@ -465,6 +465,13 @@ BiocManager::install("<%=@package[:Package]%>")</pre>
 			<td>git clone <%=get_source_url(@package, @item, @item_rep, "ssh")%></td>
 		    </tr>
 		<% end %>
+		
+        <% if package_in_code_browser(@package, @item) %>
+            <tr class="<%=ri.rowclass%>">
+                <td>Bioc Package Browser</td>
+                <td><a href="<%=get_code_browser_url(@package, include_branch=true)%>"><%=get_code_browser_url(@package, include_branch=false)%></a></td>
+            </tr>
+        <% end %>
 
 		    <tr class="<%=ri.rowclass%>">
 			<td>Package Short Url</td>

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1101,13 +1101,13 @@ end
 
 # try to determine if a package is in the code brower based on biocViews
 def package_in_code_browser(package, item)
+    # Skip anything that's not a software package
+    segs = item.identifier.to_s.split('/')
+    return false if segs[5] != "bioc"
     # Deprecated package are missing in the code browser
     return false if package[:PackageStatus] == "Deprecated"
     # Skip if we can't determine the git branch
     return false if package[:git_branch].nil?
-    # Skip anything that's not a software package
-    segs = item.identifier.to_s.split('/')
-    return false if segs[5] != "bioc"
     # if we get here, it's probably in the code browser
     return true
 end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1099,6 +1099,28 @@ def get_source_url(package, item, item_rep, access_type)
     end
 end
 
+# try to determine if a package is in the code brower based on biocViews
+def package_in_code_browser(package, item)
+    # Deprecated package are missing in the code browser
+    return false if package[:PackageStatus] == "Deprecated"
+    # Skip if we can't determine the git branch
+    return false if package[:git_branch].nil?
+    # Skip anything that's not a software package
+    segs = item.identifier.to_s.split('/')
+    return false if segs[5] != "bioc"
+    # if we get here, it's probably in the code browser
+    return true
+end
+
+# create URL for package in code browser 
+def get_code_browser_url(package, include_branch=true)
+    url = "https://code.bioconductor.org/browse/" + package[:Package] + "/"
+    if include_branch
+      url = url + package[:git_branch] + "/"
+    end
+    return url
+end
+
 def get_video_title(video)
    response = HTTParty.get(video, :verify => false)
    doc = Nokogiri::HTML(response.body)


### PR DESCRIPTION
This PR attempts to add links to https://code.bioconductor.org/browse/ to the landing pages of software packages.

Since the code browser only lists software packages, this appears for those: ![Selection_001](https://user-images.githubusercontent.com/971237/199937189-5474b6f9-2199-4aac-a734-0be539e5b161.png)

And doesn't appear for data, annotation, or workflow packages:
![Screenshot from 2022-11-04 09-30-51](https://user-images.githubusercontent.com/971237/199937466-bb499c66-222f-495e-af74-7511097321c6.png)
![Screenshot from 2022-11-04 09-31-44](https://user-images.githubusercontent.com/971237/199937469-02cd7aa8-118a-4c2e-9596-349276bab147.png)

The text of the link is `https://code.bioconductor.org/browse/<PKG>` for both release and devel, but the actual hyperlink will go to `https://code.bioconductor.org/browse/<PKG>/RELEASE_3_16` or `https://code.bioconductor.org/browse/<PKG>/master` respectively.  This is to keep consistency with the `git clone` commands which don't mention branches.

---

To determine which packages are likely in the code browser we examine several of the fields in `package` in `lib/helpers.rb`.   I presume that `package` is populated from https://bioconductor.org/packages/3.16/bioc/VIEWS, so please correct me if I'm wrong there.

This is done in `package_in_code_browser()`. 
1. Firstly, we copy the strategy of `package_has_source_url()` and exclude non-software packages by looking for `"bioc"` in their path.  
2. We then exclude any entry with `PackageStatus: Deprecated`.  These are still found in https://bioconductor.org/packages/3.16/bioc/VIEWS but missing from code.bioconductor.org e.g. [**flowUtils**](https://code.bioconductor.org/browse/flowUtils)
3. In order to use the correct branch for the hyperlink, we use `package[:git_branch]`.  A small number of entries are missing `git_branch` in https://bioconductor.org/packages/3.16/bioc/VIEWS e.g. **ensemblVEP** and so those are skipped too, although they are present in the code browser.  This is sub-optimal, but it only affects 8 packages and they all seem to have build problems, so maybe this is related to that. ("ensemblVEP", "Rnits", TVTB", "PrecisionTrialDrawer", "GAPGOM", MMAPPR2", "pulsedSilac", "phemd").
4. Any packages that is software, not deprecated, and has a `git_branch` is given a URL.
