### PR TITLE
Move slackin app from Heroku to JS2

### DIFF
--- a/content/about/community-advisory-board.md
+++ b/content/about/community-advisory-board.md
@@ -171,7 +171,7 @@ There is an annual expression of interest process inviting new members to apply 
 Also: Community members interested but not elected to CAB, or that would like more specialized work would be encouraged to volunteer to be part of a working group organized by the CAB/TAB -- there is a soon to be released page where we will list the active and inactive (needing someone to lead) working groups and for community members to suggest working groups.
 
 ### Is there a recommended way for community members to give suggestions to the CAB?
-We are happy to receive suggestions and feedback and recommend reaching us via email (cab@bioconductor.org) or by messaging us on the #community-advisory-board channel of the Bioconductor community slack ([bioc-community.herokuapp.com](https://bioc-community.herokuapp.com/)).
+We are happy to receive suggestions and feedback and recommend reaching us via email (cab@bioconductor.org) or by messaging us on the #community-advisory-board channel of the Bioconductor community slack ([slack.bioconductor.org](https://slack.bioconductor.org/)).
 (See also: A for the previous Q.)
 
 ### Are there any big new CAB projects or plans on the horizon?

--- a/content/developers/new-developer-program.md
+++ b/content/developers/new-developer-program.md
@@ -48,5 +48,5 @@ We are excited to announce our first group of 6 mentors are [Federico Marini](ht
 
 ## More information
 
-For more information about the program see the [Bioconductor New Developer Mentorship and Assistance statement](https://docs.google.com/document/d/1Q-Hxmy0ZcKzKSbB-dtg02gJRlZ0Vi6WNOTF-W3bwjmY/edit?usp=sharing). For announcements or to contact the program, please message the team via the `#developers-mentorship` slack channel on [Community-Bioc Slack](https://bioc-community.herokuapp.com/). 
+For more information about the program see the [Bioconductor New Developer Mentorship and Assistance statement](https://docs.google.com/document/d/1Q-Hxmy0ZcKzKSbB-dtg02gJRlZ0Vi6WNOTF-W3bwjmY/edit?usp=sharing). For announcements or to contact the program, please message the team via the `#developers-mentorship` slack channel on [Community-Bioc Slack](https://slack.bioconductor.org/). 
 

--- a/content/help/education-training.md
+++ b/content/help/education-training.md
@@ -52,7 +52,7 @@ lessons are developed as modules in their own repositories.
 
 - The [Google group](https://groups.google.com/g/bioconductor-teaching/).
 - The `education-and-training` channel on the [Bioconductor comunity
-  slack](https://bioc-community.herokuapp.com/).
+  slack](https://slack.bioconductor.org/).
 
 ## Contact
 

--- a/layouts/_use.html
+++ b/layouts/_use.html
@@ -19,7 +19,7 @@
       the <a href="https://anvilproject.org">AnVIL</a>. See
       our <a href="https://anvil.bioconductor.org">project
         updates</a>.</li>
-    <li><a class="symlink" href="https://bioc-community.herokuapp.com/">Community Slack</a> sign-up<li>
+    <li><a class="symlink" href="https://slack.bioconductor.org/">Community Slack</a> sign-up<li>
     <li><a class="symlink" href="/help/support/">Support site</a></li>
     <li><a class="symlink" href="http://bioconductor.org/help/events/">Events
 	      calendar</a>; email <i>events at bioconductor.org</i> to add an


### PR DESCRIPTION
URL changed from [bioc-community.herokuapp.com](http://bioc-community.herokuapp.com/) to [slack.bioconductor.org](http://slack.bioconductor.org/)