### PR TITLE
add HTML landing page link

### DIFF
--- a/layouts/components/packages/documentation.html
+++ b/layouts/components/packages/documentation.html
@@ -32,6 +32,9 @@
     <tr>
       <td>Reference Manual</td>
       <td>
+        <a href="../manuals/<%=@package[:Package]%>/man/<%=@package[:Package]%>.html">HTML</a>
+      </td>
+      <td>
         <a href="../manuals/<%=@package[:Package]%>/man/<%=@package[:Package]%>.pdf">PDF</a>
       </td>
     </tr>


### PR DESCRIPTION
In preparation for the HTML manual pages, I've added a cell to the table for linking the HTML pages along side the PDF versions.

Note :warning:  This should be merged when the HTML manuals have been created. 