### PR TITLE
add expanding ORCID iD icons

### DIFF
--- a/assets/style/pages/orcid.css
+++ b/assets/style/pages/orcid.css
@@ -1,0 +1,41 @@
+/* Base container styling */
+a.orcid-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+/* Base icon styling */
+img.orcid-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: block;
+}
+
+/* Hidden expanded text */
+span.orcid-expanded {
+  position: absolute;
+  left: 0;
+  height: 16px;
+  line-height: 16px;
+  background-color: #A6CE39;
+  border-radius: 8px;
+  color: white;
+  font-size: 12px;
+  white-space: nowrap;
+  padding: 0 10px 0 20px; /* Space for the icon plus right padding */
+  overflow: hidden;
+  max-width: 0; /* Start with no width */
+  opacity: 0;
+  transition: max-width 0.3s ease, opacity 0.2s ease;
+  pointer-events: none;
+}
+
+/* Hover effect to show expanded text */
+a.orcid-container:hover span.orcid-expanded {
+  max-width: 200px; /* Allow the content to expand */
+  opacity: 1;
+}

--- a/layouts/_sitehead.html
+++ b/layouts/_sitehead.html
@@ -61,6 +61,7 @@
   <link rel="stylesheet" type="text/css" href="/style/pages/learn-and-dev.css" media="screen" />
   <link rel="stylesheet" type="text/css" href="/style/pages/about.css" media="screen" />
   <link rel="stylesheet" type="text/css" href="/style/pages/packages.css" media="screen"/>
+  <link rel="stylesheet" type="text/css" href="/style/pages/orcid.css" media="screen"/>
 
   <link rel="SHORTCUT ICON" type="image/x-icon" href="/favicon.ico" />
   <link rel="ICON" type="image/x-icon" href="/favicon.ico" />

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -206,7 +206,15 @@ def filter_emails(str)
       url_match = email.match(/<([^>]+)>/)
       if url_match
         orcid_url = url_match[1]
-        email2 = "<a title='orcid' href='#{orcid_url}'><img src='/images/orcid.png'/></a>"
+        orcid_id = orcid_url.split('/').last
+
+         email2 = <<-HTML
+           <a href="#{orcid_url}" title="ORCID iD" class="orcid-container">
+             <img src="/images/orcid.png" alt="ORCID iD" class="orcid-icon">
+             <span class="orcid-expanded"> ORCID: #{orcid_id} </span>
+           </a>
+         HTML
+
         str = str.gsub(email, email2)
       end
     else


### PR DESCRIPTION
This change should make the ORCID iD a bit more visible when they are hovered over. See an example below.

![orcid_id](https://github.com/user-attachments/assets/e1f8b3de-417e-404e-9daf-cca835161b75)
