### PR TITLE
feature: increase bioc views table accessibility

### DIFF
--- a/assets/js/bioc_views.js
+++ b/assets/js/bioc_views.js
@@ -51,14 +51,14 @@ var displayPackages = function (packageList, nodeName) {
     var url = getHostUrl() + "/" + map[category] + "/html/" + pkg + ".html";
     //tableData += '<tr class="'+rowClass+'" id="pkg_' + pkg + '">\n';
     tableData += '<tr role="row" id="pkg_' + pkg + '">\n';
-    tableData += '\t<td><a href="' + url + '" aria-label="View details about ' + pkg + '">' + pkg + "</a></td>\n";
+    tableData += '\t<td role="cell" tabindex="0"><a href="' + url + '" aria-label="View details about ' + pkg + '">' + pkg + "</a></td>\n";
     var cleanMaintainer = packageInfo[pkg]["Maintainer"].replace(
       / *<[^>]*>/g,
       ""
     );
-    tableData += '\t<td role="cell">' + cleanMaintainer + "</td>\n";
-    tableData += '\t<td role="cell">' + packageInfo[pkg]["Title"] + "</td>\n";
-    tableData += '\t<td role="cell">' + packageInfo[pkg]["Rank"] + "</td>\n";
+    tableData += '\t<td role="cell" tabindex="0">' + cleanMaintainer + "</td>\n";
+    tableData += '\t<td role="cell" tabindex="0">' + packageInfo[pkg]["Title"] + "</td>\n";
+    tableData += '\t<td role="cell" tabindex="0">' + packageInfo[pkg]["Rank"] + "</td>\n";
     tableData += "</tr>\n";
   }
   html += tableData;

--- a/assets/js/bioc_views.js
+++ b/assets/js/bioc_views.js
@@ -36,12 +36,12 @@ var displayPackages = function (packageList, nodeName) {
   };
 
   html +=
-    "<table id='biocViews_package_table' aria-label='Packages table'>" +
+    "<table role='table' id='biocViews_package_table' aria-label='Packages table' tabindex='0'>\n" +
     "<thead><tr role='row'>" +
-    "<th scope='col'>Package</th>" +
-    "<th scope='col'>Maintainer</th>" +
-    "<th scope='col'>Title</th>" +
-    "<th scope='col'>Rank</th>" +
+    "<th role='columnheader' scope='col'>Package</th>" +
+    "<th role='columnheader' scope='col'>Maintainer</th>" +
+    "<th role='columnheader' scope='col'>Title</th>" +
+    "<th role='columnheader' scope='col'>Rank</th>" +
     "</tr></thead><tbody>\n";
 
   var tableData = "";


### PR DESCRIPTION
I added `tabindex="0"` and some `role`s to make the table more accessible. I tested this with orca on ubuntu and was able to tab through the table. 