### PR TITLE
add z-index to expanded element to hover over other ORCID icons

### DIFF
--- a/assets/style/pages/orcid.css
+++ b/assets/style/pages/orcid.css
@@ -37,5 +37,6 @@ span.orcid-expanded {
 /* Hover effect to show expanded text */
 a.orcid-container:hover span.orcid-expanded {
   max-width: 200px; /* Allow the content to expand */
+  z-index: 1;
   opacity: 1;
 }


### PR DESCRIPTION
Refers to a minor issue when there are other ORCID icons in the landing page.
This fix will keep the behavior of the expanded element _above_ an existing container
Thanks!