### PR TITLE
Correct the mistake in RandRustBinding.yaml

### DIFF
--- a/content/help/events/RandRustBinding.yaml
+++ b/content/help/events/RandRustBinding.yaml
@@ -1,7 +1,7 @@
 title: "R & Rust binding"
 location: "Virtual"
 event_host: "Developer forum"
-start: 2025-06-28
-end: 2025-06-28
+start: 2025-07-28
+end: 2025-07-28
 link:
-  text: Open to all Bioconductor and Rust developers interested on developing packages for Bioconductor and CRAN.
+  text: Open to all Bioconductor and Rust developers interested in developing packages for Bioconductor and CRAN.


### PR DESCRIPTION
I would like to make corrections to https://github.com/Bioconductor/bioconductor.org/pull/329
, including [the incorrect month](https://github.com/Bioconductor/bioconductor.org/pull/329#discussion_r2193220785
) and [the preposition](https://github.com/Bioconductor/bioconductor.org/pull/329#discussion_r2191228971).

