### PR TITLE
Switch from big-sur-arm64 to sonoma-arm64 in bioc 3.23

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -978,8 +978,8 @@ def get_mac_packs(package, item)
     end
 
     if version >= Gem::Version.new('3.23')
-        os <<  "macOS Binary (x86_64)" << "macOS Binary (arm64)"
-        osvers << "mac.binary.big-sur-x86_64.ver" << "mac.binary.sonoma-arm64.ver"
+        os <<  "macOS Binary (x86_64)" << "macOS Binary (big-sur-arm64)" << "macOS Binary (sonoma-arm64)"
+        osvers << "mac.binary.big-sur-x86_64.ver" << "mac.binary.big-sur-arm64.ver" << "mac.binary.sonoma-arm64.ver"
     end
 
     os.each_with_index do |this_os, i|

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -977,6 +977,11 @@ def get_mac_packs(package, item)
         osvers << "mac.binary.big-sur-x86_64.ver" << "mac.binary.big-sur-arm64.ver"
     end
 
+    if version >= Gem::Version.new('3.23')
+        os <<  "macOS Binary (x86_64)" << "macOS Binary (arm64)"
+        osvers << "mac.binary.big-sur-x86_64.ver" << "mac.binary.sonoma-arm64.ver"
+    end
+
     os.each_with_index do |this_os, i|
         h = {}
         h[:os] = this_os


### PR DESCRIPTION
If Bioconductor 3.23 then use the sonoma path of the repo. This should probably be merged after https://github.com/Bioconductor/BBS/pull/468.