### PR TITLE
Fix duplicate labels for mac binaries, label x86_64 as big-sur

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -972,13 +972,13 @@ def get_mac_packs(package, item)
         osvers << "mac.binary.ver" << "mac.binary.big-sur-arm64.ver"
     end
     
-    if version >= Gem::Version.new('3.17')
+    if version >= Gem::Version.new('3.17') and version <= Gem::Version.new('3.22')
         os <<  "macOS Binary (x86_64)" << "macOS Binary (arm64)"
         osvers << "mac.binary.big-sur-x86_64.ver" << "mac.binary.big-sur-arm64.ver"
     end
 
     if version >= Gem::Version.new('3.23')
-        os <<  "macOS Binary (x86_64)" << "macOS Binary (big-sur-arm64)" << "macOS Binary (sonoma-arm64)"
+        os <<  "macOS Binary (big-sur-x86_64)" << "macOS Binary (big-sur-arm64)" << "macOS Binary (sonoma-arm64)"
         osvers << "mac.binary.big-sur-x86_64.ver" << "mac.binary.big-sur-arm64.ver" << "mac.binary.sonoma-arm64.ver"
     end
 


### PR DESCRIPTION
Unfortunately, my PR to add sonoma binaries created duplication. This PR properly limits the old style to Bioc 3.17 - 3.22 while also labeling the x86_64 binaries for clarity.

<img width="754" height="780" alt="image" src="https://github.com/user-attachments/assets/09533276-76b7-4c3e-bc27-0971cc107ae1" />
