### PR TITLE
Fix Dockerfile build on Debian Buster and switch manifest clone instructions to https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ruby:2.6.5
 
+## Fix apt sources for archived Debian Buster
+RUN sed -i 's|deb.debian.org/debian|archive.debian.org/debian|g' /etc/apt/sources.list \
+ && sed -i '/security.debian.org/d' /etc/apt/sources.list
+
 ## System dependencies
 RUN apt-get update && apt-get install -y \
     rsync \

--- a/README.md
+++ b/README.md
@@ -815,7 +815,11 @@ It contains a list of all current Bioconductor packages. Make sure that
 it is in the same folder as the `bioconductor.org` repository checkout.
 To clone it, first ensure appropriate access rights and then run:
 
-    git clone git@git.bioconductor.org:admin/manifest.git
+`git clone https://git.bioconductor.org/admin/manifest`
+
+or, if you have Bioconductor SSH credentials:
+
+`git clone git@git.bioconductor.org:admin/manifest.git`
 
 #### Step 1: rake get_json
 


### PR DESCRIPTION
This PR includes:
- a small update to fix Dockerfile builds (Debian Buster → archive mirror).
- an update to th README to show https clone for the manifest repo instead of ssh, so it works for contributors without Bioconductor ssh credentials

Not included in this PR but worth noting - 
locally I created empty json files under assets/packages/json/… to prevent BiocViews/dashboard errors during preview. I did not commit those, as production/staging generate the real files via rake get_json. That should work again once the Dockerfile is updated to use a newer Ruby/R base image.

```
mkdir -p assets/packages/json/3.23/bioc
echo '{}' > assets/packages/json/3.23/bioc/packages.json
mkdir -p assets/packages/json/3.23/data/experiment 
echo '{}' > assets/packages/json/3.23/data/experiment/packages.json
```