### PR TITLE
Add link to the Metabonaut teaching resource

### DIFF
--- a/content/help/bioconductor-books.html
+++ b/content/help/bioconductor-books.html
@@ -102,6 +102,14 @@ contributed by members of the Bioconductor community.
               stroke="#ADD2DD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </a>
+         <a href="https://rformassspectrometry.github.io/Metabonaut/" class="text-large">Metabonaut: Let's
+            Explore and Learn to Analyze Metabolomics Data<svg
+            xmlns="http://www.w3.org/2000/svg" width="25" height="25" viewBox="0 0 25 25" fill="none">
+            <path
+              d="M13.5 9.29999L16.5 12.3M16.5 12.3L13.5 15.3M16.5 12.3L8.5 12.3M21.5 12.3C21.5 17.2706 17.4706 21.3 12.5 21.3C7.52944 21.3 3.5 17.2706 3.5 12.3C3.5 7.32942 7.52944 3.29999 12.5 3.29999C17.4706 3.29999 21.5 7.32942 21.5 12.3Z"
+              stroke="#ADD2DD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </a>
      </nav>
   </div>
 </div>


### PR DESCRIPTION
- Add a link to the books page pointing to the Metabonaut set of tutorials to analyze metabolomics data with Bioconductor.