### PR TITLE
Clarify course materials page as historical archive

### DIFF
--- a/content/help/course-materials.html
+++ b/content/help/course-materials.html
@@ -21,8 +21,22 @@
 } );
 </script>
 
-
 <h1><img src="/images/icons/help.gif" alt="" />Courses &amp; Conferences</h1>
+
+<p>
+  Bioconductor training resources are currently available through several platforms. We are working towards improved discovery and aggregation of training materials through integration with ELIXIR TeSS. In the meantime, the following resources may be useful:</p>
+
+<ul>
+  <li><a href="https://training.bioconductor.org">Training workshops and upcoming training events</a></li>
+  <li><a href="https://zenodo.org/communities/bioconductor">Training materials and course resources</a></li>
+  <li><a href="https://www.youtube.com/@Bioconductor">Recorded talks, seminars, and conference videos</a></li>
+  <li><a href="/help/events/">Upcoming Bioconductor events</a></li>
+</ul>
+
+<p>
+The material listed below serves as an archive of historical Bioconductor courses, workshops, and conferences.
+</p>
+
 
 <p>Bioconductor provides training in computational and statistical
    methods for the analysis of genomic data. You are welcome to use


### PR DESCRIPTION
Add signposting to current Bioconductor training resources and clarify that this page serves as an archive of historical course materials.