### PR TITLE
Filter past events out of the homepage carousel

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -453,7 +453,13 @@ def top_events(events)
   sorted = events.children.sort do |a, b|
       a[:start] <=> b[:start]
   end
-  toplist = sorted[-5..-1]
+  upcoming = sorted.select do |e|
+    e[:end] >= Time.now.to_date
+  end
+  # last(5) rather than [-5..-1]: the latter returns nil when fewer than five
+  # events remain, which is now reachable because the filter above can leave
+  # any number of them.
+  toplist = upcoming.last(5)
   toplist.reverse
 end
 


### PR DESCRIPTION
Fixes #401.

`top_events()` (`lib/helpers.rb:452`) sorted events by start date and took the last five, with no date filter — so the homepage carousel showed the five chronologically-latest events whether or not they had already happened. Its two siblings both filter correctly: `upcoming_events()` at `:426` and `previous_events()` at `:446` each test `e[:end]` against today.

This applies the same filter.

### Why `last(5)` instead of keeping `[-5..-1]`

`sorted[-5..-1]` returns `nil` when the array holds fewer than five elements, and `nil.reverse` raises. That was latent before (it needed the site to have fewer than five events total) but the filter makes it reachable — any period with fewer than five upcoming events would hit it. `last(5)` returns what it has.

### Verification

Ran the before/after logic against synthetic events (3 past, 2 upcoming) on Ruby 3.2:

```
old: ["later", "soon", "past3", "past2", "past1"]
new: ["later", "soon"]
sorted[-5..-1] with 2 elements -> nil
upcoming.last(5)               -> ["soon", "later"]
```

The old path leaks all three past events; the new one returns only upcoming, newest first, and the `nil` hazard is confirmed real rather than theoretical.

I was not able to run a full site build to check this end to end — no Ruby toolchain for this repo locally, and the pinned Ruby 2.6.5 / Debian Buster image is awkward to stand up. The change is confined to one function whose only caller is `layouts/components/homepage/events.html`, so the blast radius is the homepage carousel.

### Note for reviewers

With the filter applied, the carousel will show fewer than five entries when fewer than five events are upcoming. That seemed clearly preferable to backfilling with finished events, but if the design wants exactly five slots filled, that's a different fix and worth saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBSvPwEk6sH1rhGmjPmsFq
