### PR TITLE
Stop the mobile nav drawer clipping search and Get Started

### DIFF
--- a/assets/style/sections/header.css
+++ b/assets/style/sections/header.css
@@ -171,14 +171,19 @@ input:focus::placeholder {
     transition: 0.3s;
     gap: 0;
     top: 100%;
-    height: 2px;
+    max-height: 0;
     overflow: hidden;
     opacity: 0;
   }
 
   .header-nav.active {
     opacity: 1;
-    height: 21rem;
+    /* max-height rather than a fixed height: the drawer holds the nav links,
+       the search box and the Get Started button, and a hard 21rem clipped the
+       last two out of view with no way to scroll to them. Sizing to content
+       keeps them reachable however many nav items there are. */
+    max-height: 100vh;
+    overflow-y: auto;
   }
 
   .nav-mobile {


### PR DESCRIPTION
Fixes #400.

`.header-nav.active` (`assets/style/sections/header.css:181`) set a hardcoded `height: 21rem` while `.header-nav` sets `overflow: hidden`. The drawer contains three things — the nav links, the site search form, and the Get Started button — and at 390 px the six nav links consume the full 21rem on their own. The search box and button rendered below the clip, present in the DOM but unreachable, with no scrollbar because the overflow is hidden rather than auto.

### The change

```diff
-    height: 2px;
+    max-height: 0;

 .header-nav.active {
-    height: 21rem;
+    max-height: 100vh;
+    overflow-y: auto;
```

`max-height` rather than `height: auto` specifically because the drawer animates via `transition: 0.3s` — `height: auto` is not animatable, `max-height` is. `overflow-y: auto` is a fallback for viewports too short to fit the drawer at all.

### Measured

Rendered the real `layouts/components/header.html` markup against the real stylesheets in headless Chromium at 390×844, and measured both states:

| | drawer height | content height | search box | Get Started |
|---|---|---|---|---|
| `height: 21rem` (before) | 336 px | 440 px | 404–429 **clipped** | 445–493 **clipped** |
| `max-height` (after) | 457 px | 457 px | 404–446 visible | 462–510 visible |

Absolute offsets differ slightly from the figures in #400 because this repro renders the header standalone rather than in a full page, but the clipping reproduces exactly and the fix resolves it.

### Not included

#400 also mentions two related clipping/typography problems — `.content { overflow: hidden }` in `layouts.css:32` and `.page-container * { font-size: 1rem }` in `learn-and-dev.css:171-173`. I've left both alone. Removing `overflow: hidden` from `.content` can change layout wherever it is currently containing floats, and the font-size rule affects the whole type scale on small screens; both want a visual pass across pages rather than a blind edit. Happy to do them as a follow-up if someone can eyeball the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBSvPwEk6sH1rhGmjPmsFq
