### PR TITLE
Make links visually distinguishable from body text

### DIFF
--- a/assets/style/base/typography.css
+++ b/assets/style/base/typography.css
@@ -56,8 +56,17 @@ h6,
   border: none;
 }
 
+/* Links need to differ from body text to be recognisable as links. Components
+   that need another treatment (header, footer, buttons) already set their own
+   colour, so this only affects links in body content.
+
+   --misc-neutral is chosen over the nearer brand tokens because it clears both
+   thresholds at once: 4.90:1 against the white background (WCAG AA text) and
+   4.11:1 against --default-body (WCAG 1.4.1, which wants 3:1 when colour alone
+   separates a link from its surrounding text). --primary-p400 manages 8.06:1 on
+   white but only 2.50:1 against body text; --primary is the reverse. */
 a {
-  color: black;
+  color: var(--misc-neutral);
 }
 
 @media (max-device-width: 768px),(width <= 768px){

--- a/assets/style/sections/footer.css
+++ b/assets/style/sections/footer.css
@@ -15,7 +15,12 @@ footer {
 
 footer * {
   color: #fff;
-  text-decoration: none;
+}
+
+/* Footer links keep the white needed for contrast on the dark background, so
+   the underline is the only thing marking them as links. */
+footer a {
+  text-decoration: underline;
 }
 
 .footer-container {


### PR DESCRIPTION
Fixes #399.

Two rules between them removed every visual cue that something is a link:

- `assets/style/base/typography.css:59` — `a { color: black }`, and `body` is `--default-body` (#070707). Links were effectively the same colour as the text around them.
- `assets/style/sections/footer.css:16-19` — `footer * { color: #fff; text-decoration: none }` stripped the underline from every footer link, so footer links had neither colour nor underline.

### Choosing the colour

I picked `--misc-neutral` (#007a9f) after checking the existing tokens against both thresholds that apply here — contrast against the background (WCAG AA, 4.5:1) *and* contrast against surrounding body text (WCAG 1.4.1, 3:1, which applies when colour is what separates a link from its text):

| token | | on white | vs body text | |
|---|---|---|---|---|
| `--primary-p400` | #035771 | 8.06 | **2.50** | fails vs body |
| `--primary` | #3792ad | **3.57** | 5.64 | fails on white |
| `--primary-p500` | #003242 | 13.68 | **1.47** | fails vs body |
| `--primary-p200` | #59a5bb | **2.79** | 7.22 | fails on white |
| **`--misc-neutral`** | **#007a9f** | **4.90** | **4.11** | **passes both** |

My first attempt used `--primary-p400`, which looks like the obvious brand choice and has excellent contrast on white — but only 2.50:1 against body text, so it would have traded one indistinguishability problem for a subtler one.

In the footer the background is #121212, so white has to stay for contrast (18.73:1) and the underline does the work instead.

### Verified

Rendered the real header, a body paragraph, and the real footer against the actual stylesheets in headless Chromium:

```
body text    rgb(7, 7, 7)     none
body link    rgb(0, 122, 159) underline
header link  rgb(7, 7, 7)     none        <- unchanged
footer link  rgb(255,255,255) underline
```

Header links are unaffected because `.header-size a` sets `--misc-dark` explicitly; the same is true of `.header-button` and everything in `buttons.css`. The change reaches links in body content, which is the intent.

### Worth a human eye

This is a small diff with site-wide visual reach, and I can't build the full site locally to check it across page types. Body-content links on generated package landing pages in particular are worth a look before merging — that's ~7,600 pages inheriting the base rule with their own legacy CSS alongside it.

If the project would rather keep links black, the alternative that still satisfies #399 is to give body links a permanent underline and leave the colour alone. That's a one-line change in the same place; say the word and I'll swap it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBSvPwEk6sH1rhGmjPmsFq
