### PR TITLE
Add Bioc developer survey to banner

### DIFF
--- a/layouts/components/announcement.html
+++ b/layouts/components/announcement.html
@@ -6,6 +6,6 @@
  </svg>
 
      <p style="font-size:125%">
-	 <a href="https://bioc2026.bioconductor.org/">Bioc2026</a> Registration Open!
+	 <a href="https://forms.gle/LWFZuCdkeGUKe7vG8">Bioconductor Developer Survey 2026 Now Open!</a> 
      </p>
 </div>


### PR DESCRIPTION
@npcooley @lshep FYI, draft PR to replace the BioC2026 registration banner with the developer survey banner. Happy to tweak the wording if needed.